### PR TITLE
fix: prevent AppCard tag overflow on Browse Projects page

### DIFF
--- a/packages/frontend/src/sharedComponents/AppsGrid/AppCard.tsx
+++ b/packages/frontend/src/sharedComponents/AppsGrid/AppCard.tsx
@@ -69,21 +69,27 @@ const AppCard: React.FC<
         {/* Tags section pushed to bottom */}
         <div className="mt-auto mb-3">
           {(() => {
+            const MAX_VISIBLE_TAGS = 3;
             const allTags = [
-              ...(categories?.map((cat) => ({ text: cat, type: "category" })) ??
-                []),
-              ...(badges?.map((badge) => ({ text: badge, type: "badge" })) ??
-                []),
+              ...(categories?.map((cat, index) => ({
+                text: cat,
+                type: "category",
+                id: `category-${index}`,
+              })) ?? []),
+              ...(badges?.map((badge, index) => ({
+                text: badge,
+                type: "badge",
+                id: `badge-${index}`,
+              })) ?? []),
             ];
-            const maxVisibleTags = 3;
-            const visibleTags = allTags.slice(0, maxVisibleTags);
-            const hiddenCount = allTags.length - maxVisibleTags;
+            const visibleTags = allTags.slice(0, MAX_VISIBLE_TAGS);
+            const hiddenCount = allTags.length - MAX_VISIBLE_TAGS;
 
             return (
               <>
                 {visibleTags.map((tag) => (
                   <span
-                    key={`${tag.type}-${tag.text}`}
+                    key={tag.id}
                     className={`${
                       tag.type === "category" ? "tag" : "tag-mcu"
                     } text-xs font-semibold mr-2 px-2.5 py-0.5 rounded-full`}
@@ -95,7 +101,7 @@ const AppCard: React.FC<
                   <span
                     className="text-xs text-slate-500 font-medium cursor-help"
                     title={allTags
-                      .slice(maxVisibleTags)
+                      .slice(MAX_VISIBLE_TAGS)
                       .map((tag) => tag.text)
                       .join(", ")}
                   >

--- a/packages/frontend/src/sharedComponents/AppsGrid/AppCard.tsx
+++ b/packages/frontend/src/sharedComponents/AppsGrid/AppCard.tsx
@@ -68,22 +68,43 @@ const AppCard: React.FC<
 
         {/* Tags section pushed to bottom */}
         <div className="mt-auto mb-3">
-          {categories?.map((category) => (
-            <span
-              key={category}
-              className="tag text-xs font-semibold mr-2 px-2.5 py-0.5 rounded-full"
-            >
-              {category}
-            </span>
-          )) ?? false}
-          {badges?.map((badge) => (
-            <span
-              key={badge}
-              className="tag-mcu text-xs font-semibold mr-2 px-2.5 py-0.5 rounded-full"
-            >
-              {badge}
-            </span>
-          )) ?? false}
+          {(() => {
+            const allTags = [
+              ...(categories?.map((cat) => ({ text: cat, type: "category" })) ??
+                []),
+              ...(badges?.map((badge) => ({ text: badge, type: "badge" })) ??
+                []),
+            ];
+            const maxVisibleTags = 3;
+            const visibleTags = allTags.slice(0, maxVisibleTags);
+            const hiddenCount = allTags.length - maxVisibleTags;
+
+            return (
+              <>
+                {visibleTags.map((tag) => (
+                  <span
+                    key={`${tag.type}-${tag.text}`}
+                    className={`${
+                      tag.type === "category" ? "tag" : "tag-mcu"
+                    } text-xs font-semibold mr-2 px-2.5 py-0.5 rounded-full`}
+                  >
+                    {tag.text}
+                  </span>
+                ))}
+                {hiddenCount > 0 && (
+                  <span
+                    className="text-xs text-slate-500 font-medium cursor-help"
+                    title={allTags
+                      .slice(maxVisibleTags)
+                      .map((tag) => tag.text)
+                      .join(", ")}
+                  >
+                    +{hiddenCount} more
+                  </span>
+                )}
+              </>
+            );
+          })()}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Limit visible tags to 3 with '+X more' indicator for overflow
- Add interactive tooltip to '+X more' showing all hidden tags on hover
- Combine categories and badges in single tag display logic
- Maintains fixed card height while preserving access to all tag information

## Problem
When apps have multiple categories and/or supported badges (typically added via API), the tag list overflows the fixed-height AppCard on the Browse Projects page, causing layout disruption and cutting off important metadata.

## Solution
- **Smart Tag Limiting**: Shows first 3 tags (categories + badges combined)
- **Overflow Indicator**: Displays "+X more" when additional tags exist
- **Interactive Tooltip**: Hover over "+X more" to see comma-separated list of all hidden tags
- **Visual Cues**: Added `cursor-help` to indicate hoverable element

## Test Plan
- [x] TypeScript checks pass
- [x] Linting passes
- [x] All frontend tests pass (18 tests)
- [x] Cards maintain consistent height with many tags
- [x] Tooltip displays correctly with hidden tag information
- [x] No layout disruption in project grid

## Screenshots/Demo
The fix ensures:
- Clean, organized grid layout preserved
- Essential tag information still visible
- Complete tag access via intuitive tooltip interaction
- Better UX for apps with extensive metadata

## Addresses
Closes #185 - AppCard tags overflow on Browse Projects page when apps have many categories/badges

This solution provides the optimal balance between clean UI design and complete information accessibility.