### PR TITLE
Improve AppCard tag display to prevent overflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,6 @@ data
 
 # intellij IDE
 .idea
+
+# Claude local documentation
+CLAUDE.local.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -2594,6 +2594,15 @@
         "@types/send": "*"
       }
     },
+    "node_modules/@types/hast": {
+      "version": "2.3.10",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.10.tgz",
+      "integrity": "sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2"
+      }
+    },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
@@ -2693,6 +2702,16 @@
         "@types/react": "^19.0.0"
       }
     },
+    "node_modules/@types/react-syntax-highlighter": {
+      "version": "15.5.13",
+      "resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-15.5.13.tgz",
+      "integrity": "sha512-uLGJ87j6Sz8UaBAooU0T6lWJ0dBmjZgN1PZTrj05TNql2/XpC6+4HhMT5syIdFUUt+FASfCeLLv4kBygNU+8qA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/readable-stream": {
       "version": "4.0.21",
       "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.21.tgz",
@@ -2759,6 +2778,12 @@
         "@types/express": "*",
         "@types/serve-static": "*"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -3871,6 +3896,36 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/character-entities": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
+      "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
+      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
+      "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/charm": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz",
@@ -4076,6 +4131,16 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
+      "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/commander": {
@@ -5402,6 +5467,19 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fault": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
+      "integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
+      "license": "MIT",
+      "dependencies": {
+        "format": "^0.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/fclone": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/fclone/-/fclone-1.0.11.tgz",
@@ -5579,6 +5657,14 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/format": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "integrity": "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==",
+      "engines": {
+        "node": ">=0.4.x"
       }
     },
     "node_modules/formidable": {
@@ -5900,11 +5986,53 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-parse-selector": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.5.tgz",
+      "integrity": "sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-6.0.0.tgz",
+      "integrity": "sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^2.0.0",
+        "comma-separated-tokens": "^1.0.0",
+        "hast-util-parse-selector": "^2.0.0",
+        "property-information": "^5.0.0",
+        "space-separated-tokens": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/help-me": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
       "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
       "license": "MIT"
+    },
+    "node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/highlightjs-vue": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/highlightjs-vue/-/highlightjs-vue-1.0.0.tgz",
+      "integrity": "sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==",
+      "license": "CC0-1.0"
     },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
@@ -6112,6 +6240,30 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-alphabetical": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
+      "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
+      "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^1.0.0",
+        "is-decimal": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
@@ -6145,6 +6297,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-decimal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
+      "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -6173,6 +6335,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
+      "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-number": {
@@ -6504,6 +6676,20 @@
       "integrity": "sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lowlight": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.20.0.tgz",
+      "integrity": "sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==",
+      "license": "MIT",
+      "dependencies": {
+        "fault": "^1.0.0",
+        "highlight.js": "~10.7.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -7207,6 +7393,24 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/parse-entities": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
+      "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^1.0.0",
+        "character-entities-legacy": "^1.0.0",
+        "character-reference-invalid": "^1.0.0",
+        "is-alphanumerical": "^1.0.0",
+        "is-decimal": "^1.0.0",
+        "is-hexadecimal": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/parse5": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
@@ -7814,6 +8018,15 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/prismjs": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -7874,6 +8087,19 @@
       "license": "MIT",
       "dependencies": {
         "read": "^1.0.4"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.6.0.tgz",
+      "integrity": "sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/proxy-addr": {
@@ -8109,6 +8335,23 @@
         "node": ">=18"
       }
     },
+    "node_modules/react-syntax-highlighter": {
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-15.6.1.tgz",
+      "integrity": "sha512-OqJ2/vL7lEeV5zTJyG7kmARppUjiB9h9udl4qHQjjgEos66z00Ia0OckwYfRxCSFrW8RJIBnsBwQsHZbVPspqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.3.1",
+        "highlight.js": "^10.4.1",
+        "highlightjs-vue": "^1.0.0",
+        "lowlight": "^1.17.0",
+        "prismjs": "^1.27.0",
+        "refractor": "^3.6.0"
+      },
+      "peerDependencies": {
+        "react": ">= 0.14.0"
+      }
+    },
     "node_modules/read": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
@@ -8168,6 +8411,30 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/refractor": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/refractor/-/refractor-3.6.0.tgz",
+      "integrity": "sha512-MY9W41IOWxxk31o+YvFCNyNzdkc9M20NoZK5vq6jkv4I/uh2zkWcfudj0Q1fovjUQJrNewS9NMzeTtqPf+n5EA==",
+      "license": "MIT",
+      "dependencies": {
+        "hastscript": "^6.0.0",
+        "parse-entities": "^2.0.0",
+        "prismjs": "~1.27.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/refractor/node_modules/prismjs": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
+      "integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/require-directory": {
@@ -8787,6 +9054,16 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
+      "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/spawn-command": {
@@ -10279,21 +10556,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/yaml": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      }
-    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -10493,7 +10755,8 @@
         "keycloak-js": "^26.2.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "react-router-dom": "^7.6.2"
+        "react-router-dom": "^7.6.2",
+        "react-syntax-highlighter": "^15.6.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -10503,6 +10766,7 @@
         "@types/node": "^22.15.29",
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
+        "@types/react-syntax-highlighter": "^15.5.13",
         "@vitejs/plugin-react": "^4.4.1",
         "@vitest/coverage-v8": "^3.1.4",
         "autoprefixer": "^10.4.21",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "prepare": "husky",
     "lint-staged": "pretty-quick --staged",
     "lint": "pretty-quick --check",
-    "lint:fix": "pretty-quick --check",
+    "lint:fix": "pretty-quick",
     "validate": "npm run lint && npm run check:ts && npm run build && npm run test"
   },
   "dependencies": {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -15,7 +15,8 @@
     "keycloak-js": "^26.2.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router-dom": "^7.6.2"
+    "react-router-dom": "^7.6.2",
+    "react-syntax-highlighter": "^15.6.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",
@@ -25,6 +26,7 @@
     "@types/node": "^22.15.29",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
+    "@types/react-syntax-highlighter": "^15.5.13",
     "@vitejs/plugin-react": "^4.4.1",
     "@vitest/coverage-v8": "^3.1.4",
     "autoprefixer": "^10.4.21",

--- a/packages/frontend/src/pages/AppDetailPage/AppCodePreview.test.tsx
+++ b/packages/frontend/src/pages/AppDetailPage/AppCodePreview.test.tsx
@@ -1,0 +1,217 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import AppCodePreview from "./AppCodePreview";
+import { ProjectDetails } from "@shared/domain/readModels/project/ProjectDetails";
+
+// Mock the API client
+vi.mock("@api/tsRestClient.ts", () => ({
+  publicTsRestClient: {
+    getLatestPublishedFile: vi.fn().mockImplementation(({ params }) => {
+      // Mock different responses based on file path
+      if (params.filePath === "test.json") {
+        return Promise.resolve({
+          status: 200,
+          body: '{"name": "test", "version": "1.0.0", "description": "A test JSON file"}',
+        });
+      }
+      if (params.filePath === "example.py") {
+        return Promise.resolve({
+          status: 200,
+          body: 'def hello_world():\n    print("Hello, BadgeHub!")\n    return "success"',
+        });
+      }
+      if (params.filePath === "readme.txt") {
+        return Promise.resolve({
+          status: 200,
+          body: "This is a simple text file.\nIt contains multiple lines.\nEach line is plain text.",
+        });
+      }
+      return Promise.resolve({
+        status: 404,
+        body: "File not found",
+      });
+    }),
+  },
+}));
+
+const mockProject: ProjectDetails = {
+  slug: "test-project",
+  idp_user_id: "author-id",
+  latest_revision: 1,
+  version: {
+    revision: 1,
+    files: [
+      {
+        dir: "",
+        name: "test",
+        ext: "json",
+        mimetype: "application/json",
+        size_of_content: 100,
+        sha256: "a".repeat(64),
+        size_formatted: "100 B",
+        full_path: "test.json",
+        url: "http://example.com/test.json",
+        created_at: "2023-01-01T00:00:00Z",
+        updated_at: "2023-01-01T00:00:00Z",
+      },
+      {
+        dir: "",
+        name: "example",
+        ext: "py",
+        mimetype: "text/x-python",
+        size_of_content: 200,
+        sha256: "b".repeat(64),
+        size_formatted: "200 B",
+        full_path: "example.py",
+        url: "http://example.com/example.py",
+        created_at: "2023-01-01T00:00:00Z",
+        updated_at: "2023-01-01T00:00:00Z",
+      },
+      {
+        dir: "",
+        name: "image",
+        ext: "png",
+        mimetype: "image/png",
+        image_width: 100,
+        image_height: 50,
+        size_of_content: 1024,
+        sha256: "c".repeat(64),
+        size_formatted: "1 KB",
+        full_path: "image.png",
+        url: "http://example.com/image.png",
+        created_at: "2023-01-01T00:00:00Z",
+        updated_at: "2023-01-01T00:00:00Z",
+      },
+      {
+        dir: "",
+        name: "readme",
+        ext: "txt",
+        mimetype: "text/plain",
+        size_of_content: 500,
+        sha256: "d".repeat(64),
+        size_formatted: "500 B",
+        full_path: "readme.txt",
+        url: "http://example.com/readme.txt",
+        created_at: "2023-01-01T00:00:00Z",
+        updated_at: "2023-01-01T00:00:00Z",
+      },
+      {
+        dir: "",
+        name: "document",
+        ext: "pdf",
+        mimetype: "application/pdf",
+        size_of_content: 5000,
+        sha256: "e".repeat(64),
+        size_formatted: "5 KB",
+        full_path: "document.pdf",
+        url: "http://example.com/document.pdf",
+        created_at: "2023-01-01T00:00:00Z",
+        updated_at: "2023-01-01T00:00:00Z",
+      },
+    ],
+    app_metadata: {
+      name: "Test Project",
+      version: "1.0.0",
+      description: "Test description",
+      author: "Test Author",
+    },
+    published_at: "2023-01-01T00:00:00Z",
+  },
+  created_at: "2023-01-01T00:00:00Z",
+  updated_at: "2023-01-01T00:00:00Z",
+};
+
+describe("AppCodePreview", () => {
+  it("renders the component with file list", () => {
+    render(<AppCodePreview project={mockProject} />);
+
+    expect(screen.getByText("Code Preview / Files")).toBeInTheDocument();
+    expect(screen.getByText("Project Files:")).toBeInTheDocument();
+    expect(screen.getByText("test.json")).toBeInTheDocument();
+    expect(screen.getByText("example.py")).toBeInTheDocument();
+    expect(screen.getByText("image.png")).toBeInTheDocument();
+    expect(screen.getByText("readme.txt")).toBeInTheDocument();
+    expect(screen.getByText("document.pdf")).toBeInTheDocument();
+  });
+
+  it("shows no preview message for unsupported file types", async () => {
+    render(<AppCodePreview project={mockProject} />);
+
+    // Click on PDF file
+    const pdfButton = screen.getByText("document.pdf");
+    fireEvent.click(pdfButton);
+
+    // Should show unsupported message
+    expect(
+      await screen.findByText("Preview not available for this file type.")
+    ).toBeInTheDocument();
+    expect(screen.getByText("MIME type: application/pdf")).toBeInTheDocument();
+  });
+
+  it("shows image preview for image files", async () => {
+    render(<AppCodePreview project={mockProject} />);
+
+    // Click on image file
+    const imageButton = screen.getByText("image.png");
+    fireEvent.click(imageButton);
+
+    // Should show image preview
+    expect(await screen.findByText("Image file (100×50)")).toBeInTheDocument();
+    const img = screen.getByAltText("image.png");
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute("src", "http://example.com/image.png");
+  });
+
+  it("shows JSON preview with pretty print functionality", async () => {
+    render(<AppCodePreview project={mockProject} />);
+
+    // Click on JSON file
+    const jsonButton = screen.getByText("test.json");
+    fireEvent.click(jsonButton);
+
+    // Should show JSON preview
+    expect(await screen.findByText("JSON file")).toBeInTheDocument();
+    expect(screen.getByText("Pretty Print")).toBeInTheDocument();
+
+    // Check that JSON content parts are displayed (syntax highlighting splits text)
+    expect(screen.getByText('"test"')).toBeInTheDocument();
+    expect(screen.getByText('"version"')).toBeInTheDocument();
+    expect(screen.getByText('"1.0.0"')).toBeInTheDocument();
+
+    // Test pretty print toggle
+    const prettyPrintButton = screen.getByText("Pretty Print");
+    fireEvent.click(prettyPrintButton);
+    expect(screen.getByText("Show Raw")).toBeInTheDocument();
+  });
+
+  it("shows Python preview with syntax highlighting", async () => {
+    render(<AppCodePreview project={mockProject} />);
+
+    // Click on Python file
+    const pythonButton = screen.getByText("example.py");
+    fireEvent.click(pythonButton);
+
+    // Should show Python preview
+    expect(await screen.findByText("Python file")).toBeInTheDocument();
+
+    // Check that Python code parts are displayed (syntax highlighting splits text)
+    expect(screen.getByText("def")).toBeInTheDocument();
+    expect(screen.getByText("hello_world")).toBeInTheDocument();
+    expect(screen.getByText("print")).toBeInTheDocument();
+    expect(screen.getByText('"Hello, BadgeHub!"')).toBeInTheDocument();
+  });
+
+  it("shows text preview for plain text files", async () => {
+    render(<AppCodePreview project={mockProject} />);
+
+    // Click on text file
+    const textButton = screen.getByText("readme.txt");
+    fireEvent.click(textButton);
+
+    // Should show text content
+    expect(
+      await screen.findByText(/This is a simple text file/)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/It contains multiple lines/)).toBeInTheDocument();
+  });
+});

--- a/packages/frontend/src/pages/AppDetailPage/AppCodePreview.tsx
+++ b/packages/frontend/src/pages/AppDetailPage/AppCodePreview.tsx
@@ -1,6 +1,9 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useMemo } from "react";
 import { publicTsRestClient } from "@api/tsRestClient.ts";
 import { ProjectDetails } from "@shared/domain/readModels/project/ProjectDetails.ts";
+import { FileMetadata } from "@shared/domain/readModels/project/FileMetadata.ts";
+import SyntaxHighlighter from "react-syntax-highlighter";
+import { atomOneDark } from "react-syntax-highlighter/dist/cjs/styles/hljs";
 
 const DownloadIcon = () => (
   <svg
@@ -20,11 +23,283 @@ const DownloadIcon = () => (
   </svg>
 );
 
+// Helper function to determine preview type based on mimetype
+const getPreviewType = (mimetype: string): string => {
+  if (mimetype.startsWith("image/")) {
+    return "image";
+  }
+  if (mimetype === "application/json") {
+    return "json";
+  }
+  if (
+    mimetype === "text/x-python" ||
+    mimetype === "application/x-python-code" ||
+    mimetype === "text/x-python-script"
+  ) {
+    return "python";
+  }
+  if (mimetype === "text/plain" || mimetype.startsWith("text/")) {
+    return "text";
+  }
+  return "unsupported";
+};
+
+// Helper function to detect programming language from file extension
+const getLanguageFromFile = (filename: string): string => {
+  const extension = filename.toLowerCase().split(".").pop() || "";
+  const languageMap: { [key: string]: string } = {
+    js: "javascript",
+    jsx: "jsx",
+    ts: "typescript",
+    tsx: "tsx",
+    py: "python",
+    json: "json",
+    html: "html",
+    css: "css",
+    scss: "scss",
+    sass: "sass",
+    less: "less",
+    xml: "xml",
+    yaml: "yaml",
+    yml: "yaml",
+    md: "markdown",
+    sh: "bash",
+    bash: "bash",
+    c: "c",
+    cpp: "cpp",
+    java: "java",
+    php: "php",
+    rb: "ruby",
+    go: "go",
+    rs: "rust",
+    sql: "sql",
+  };
+
+  return languageMap[extension] || "text";
+};
+
+// JSON Preview Component with pretty print option and syntax highlighting
+const JsonPreview: React.FC<{ content: string }> = ({ content }) => {
+  const [isPretty, setIsPretty] = useState(false);
+
+  const formatJson = (jsonStr: string): string => {
+    try {
+      const parsed = JSON.parse(jsonStr);
+      return JSON.stringify(parsed, null, 2);
+    } catch (error) {
+      console.warn('Invalid JSON, showing original:', error);
+      return jsonStr;
+    }
+  };
+
+  const displayContent = isPretty ? formatJson(content) : content;
+
+  return (
+    <div>
+      <div className="mb-2 flex items-center gap-2">
+        <span className="text-slate-300 text-sm">JSON file</span>
+        <button
+          onClick={() => setIsPretty(!isPretty)}
+          className="px-2 py-1 bg-slate-700 text-slate-200 rounded text-xs hover:bg-slate-600"
+        >
+          {isPretty ? "Show Raw" : "Pretty Print"}
+        </button>
+      </div>
+      <div className="rounded overflow-hidden">
+        <SyntaxHighlighter
+          language="json"
+          style={atomOneDark}
+          customStyle={{
+            background: "#1e293b", // Slate-800 to match app theme
+            padding: "1rem",
+            margin: 0,
+            fontSize: "0.875rem",
+            lineHeight: "1.25rem",
+          }}
+          showLineNumbers={false}
+          wrapLines={true}
+          wrapLongLines={true}
+        >
+          {displayContent}
+        </SyntaxHighlighter>
+      </div>
+    </div>
+  );
+};
+
+// Python Preview Component with syntax highlighting
+const PythonPreview: React.FC<{ content: string }> = ({ content }) => {
+  return (
+    <div>
+      <div className="mb-2">
+        <span className="text-slate-300 text-sm">Python file</span>
+      </div>
+      <div className="rounded overflow-hidden">
+        <SyntaxHighlighter
+          language="python"
+          style={atomOneDark}
+          customStyle={{
+            background: "#1e293b", // Slate-800 to match app theme
+            padding: "1rem",
+            margin: 0,
+            fontSize: "0.875rem",
+            lineHeight: "1.25rem",
+          }}
+          showLineNumbers={false}
+          wrapLines={true}
+          wrapLongLines={true}
+        >
+          {content}
+        </SyntaxHighlighter>
+      </div>
+    </div>
+  );
+};
+
+// Text Preview Component with syntax highlighting for recognized file types
+const TextPreview: React.FC<{ content: string; filename: string }> = ({
+  content,
+  filename,
+}) => {
+  const language = getLanguageFromFile(filename);
+
+  if (language === "text") {
+    // Plain text - use basic pre/code styling
+    return (
+      <div>
+        <div className="mb-2">
+          <span className="text-slate-300 text-sm">Text file</span>
+        </div>
+        <pre className="text-slate-300 whitespace-pre-wrap break-words">
+          <code>{content}</code>
+        </pre>
+      </div>
+    );
+  }
+
+  // Use syntax highlighting for recognized programming languages
+  return (
+    <div>
+      <div className="mb-2">
+        <span className="text-slate-300 text-sm">{language} file</span>
+      </div>
+      <div className="rounded overflow-hidden">
+        <SyntaxHighlighter
+          language={language}
+          style={atomOneDark}
+          customStyle={{
+            background: "#1e293b", // Slate-800 to match app theme
+            padding: "1rem",
+            margin: 0,
+            fontSize: "0.875rem",
+            lineHeight: "1.25rem",
+          }}
+          showLineNumbers={false}
+          wrapLines={true}
+          wrapLongLines={true}
+        >
+          {content}
+        </SyntaxHighlighter>
+      </div>
+    </div>
+  );
+};
+
+// Image Preview Component
+const ImagePreview: React.FC<{ file: FileMetadata }> = ({ file }) => {
+  return (
+    <div>
+      <div className="mb-2">
+        <span className="text-slate-300 text-sm">
+          Image file{" "}
+          {file.image_width &&
+            file.image_height &&
+            `(${file.image_width}×${file.image_height})`}
+        </span>
+      </div>
+      <div className="flex justify-center">
+        <img
+          src={file.url}
+          alt={file.full_path}
+          className="max-w-full max-h-96 rounded border border-slate-600"
+          style={{ maxHeight: "400px" }}
+        />
+      </div>
+    </div>
+  );
+};
+
+// No Preview Component for unsupported types
+const NoPreview: React.FC<{ mimetype: string }> = ({ mimetype }) => {
+  return (
+    <div className="text-center py-8 text-slate-400">
+      <p>Preview not available for this file type.</p>
+      <p className="text-sm mt-2">MIME type: {mimetype}</p>
+      <p className="text-sm">Use the download button to view the file.</p>
+    </div>
+  );
+};
+
+// Helper function to render file preview content
+const renderFilePreview = (
+  loading: boolean,
+  previewedFile: string | null,
+  currentFile: FileMetadata | null,
+  fileContent: string | null
+): React.ReactElement => {
+  if (loading) {
+    return <div className="text-slate-400">Loading file...</div>;
+  }
+
+  if (!previewedFile) {
+    return <div className="text-slate-400">No file selected</div>;
+  }
+
+  if (!currentFile) {
+    return <div className="text-slate-400">File not found</div>;
+  }
+
+  const previewType = getPreviewType(currentFile.mimetype);
+
+  switch (previewType) {
+    case "image":
+      return <ImagePreview file={currentFile} />;
+    case "json":
+      return fileContent ? (
+        <JsonPreview content={fileContent} />
+      ) : (
+        <div className="text-slate-400">Loading JSON...</div>
+      );
+    case "python":
+      return fileContent ? (
+        <PythonPreview content={fileContent} />
+      ) : (
+        <div className="text-slate-400">Loading Python file...</div>
+      );
+    case "text":
+      return fileContent ? (
+        <TextPreview
+          content={fileContent}
+          filename={currentFile.full_path}
+        />
+      ) : (
+        <div className="text-slate-400">Loading text file...</div>
+      );
+    case "unsupported":
+      return <NoPreview mimetype={currentFile.mimetype} />;
+    default:
+      return <div className="text-slate-400">Unknown file type</div>;
+  }
+};
+
 const AppCodePreview: React.FC<{ project: ProjectDetails }> = ({ project }) => {
-  const files = project?.version?.files ?? [];
+  const files = useMemo(() => project?.version?.files ?? [], [project?.version?.files]);
   const [previewedFile, setPreviewedFile] = useState<string | null>(null);
   const [fileContent, setFileContent] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+
+  // Get the currently previewed file metadata
+  const currentFile = files.find((f) => f.full_path === previewedFile) || null;
 
   // Find __init__.py by default
   useEffect(() => {
@@ -48,10 +323,25 @@ const AppCodePreview: React.FC<{ project: ProjectDetails }> = ({ project }) => {
 
   // Fetch file content when previewedFile changes
   useEffect(() => {
-    if (!previewedFile) {
+    if (!previewedFile || !currentFile) {
       setFileContent(null);
       return;
     }
+
+    // For images, we don't need to fetch content - we'll display them directly
+    if (getPreviewType(currentFile.mimetype) === "image") {
+      setFileContent(null);
+      setLoading(false);
+      return;
+    }
+
+    // For unsupported types, don't fetch content
+    if (getPreviewType(currentFile.mimetype) === "unsupported") {
+      setFileContent(null);
+      setLoading(false);
+      return;
+    }
+
     setLoading(true);
     publicTsRestClient
       .getLatestPublishedFile({
@@ -65,7 +355,10 @@ const AppCodePreview: React.FC<{ project: ProjectDetails }> = ({ project }) => {
           if (typeof res.body === "string") {
             setFileContent(res.body);
           } else if (res.body instanceof Blob) {
-            res.body.text().then(setFileContent);
+            res.body.text().then(setFileContent).catch((error) => {
+              console.error('Error reading blob content:', error);
+              setFileContent("// Error reading file content");
+            });
           } else {
             setFileContent("// Unable to display file content");
           }
@@ -73,8 +366,13 @@ const AppCodePreview: React.FC<{ project: ProjectDetails }> = ({ project }) => {
           setFileContent("// Unable to load file");
         }
         setLoading(false);
+      })
+      .catch((error) => {
+        console.error('Error fetching file:', error);
+        setFileContent("// Network error loading file");
+        setLoading(false);
       });
-  }, [previewedFile, project.slug]);
+  }, [previewedFile, project.slug, currentFile]);
 
   const handlePreview = (fullPath: string) => {
     setPreviewedFile(fullPath);
@@ -119,6 +417,12 @@ const AppCodePreview: React.FC<{ project: ProjectDetails }> = ({ project }) => {
                       : "text-slate-400"
                   }`}
                   onClick={() => handlePreview(f.full_path)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      handlePreview(f.full_path);
+                    }
+                  }}
                   style={{
                     background: "none",
                     border: "none",
@@ -126,6 +430,7 @@ const AppCodePreview: React.FC<{ project: ProjectDetails }> = ({ project }) => {
                     cursor: "pointer",
                   }}
                   title="Preview file"
+                  aria-label={`Preview ${f.full_path}`}
                 >
                   {f.full_path}
                 </button>
@@ -141,15 +446,7 @@ const AppCodePreview: React.FC<{ project: ProjectDetails }> = ({ project }) => {
       </div>
       <div className="mt-6 md:ml-0">
         <div className="code-block font-mono text-sm bg-gray-900 rounded p-4 overflow-x-auto min-h-[200px]">
-          <pre>
-            <code>
-              {loading
-                ? "// Loading file..."
-                : previewedFile
-                  ? (fileContent ?? "// Loading file...")
-                  : "// No file selected"}
-            </code>
-          </pre>
+{renderFilePreview(loading, previewedFile, currentFile, fileContent)}
         </div>
       </div>
     </section>

--- a/packages/frontend/src/pages/AppDetailPage/AppCodePreview.tsx
+++ b/packages/frontend/src/pages/AppDetailPage/AppCodePreview.tsx
@@ -87,7 +87,7 @@ const JsonPreview: React.FC<{ content: string }> = ({ content }) => {
       const parsed = JSON.parse(jsonStr);
       return JSON.stringify(parsed, null, 2);
     } catch (error) {
-      console.warn('Invalid JSON, showing original:', error);
+      console.warn('Failed to parse JSON, displaying raw content:', error);
       return jsonStr;
     }
   };
@@ -356,8 +356,8 @@ const AppCodePreview: React.FC<{ project: ProjectDetails }> = ({ project }) => {
             setFileContent(res.body);
           } else if (res.body instanceof Blob) {
             res.body.text().then(setFileContent).catch((error) => {
-              console.error('Error reading blob content:', error);
-              setFileContent("// Error reading file content");
+              console.error('Failed to read file content from server response:', error);
+              setFileContent("// Unable to read file content - please try downloading the file directly");
             });
           } else {
             setFileContent("// Unable to display file content");
@@ -368,8 +368,8 @@ const AppCodePreview: React.FC<{ project: ProjectDetails }> = ({ project }) => {
         setLoading(false);
       })
       .catch((error) => {
-        console.error('Error fetching file:', error);
-        setFileContent("// Network error loading file");
+        console.error('Failed to fetch file content from server:', error);
+        setFileContent("// Network error - please check your connection and try again");
         setLoading(false);
       });
   }, [previewedFile, project.slug, currentFile]);

--- a/packages/frontend/src/pages/AppDetailPage/AppDetailHeader.tsx
+++ b/packages/frontend/src/pages/AppDetailPage/AppDetailHeader.tsx
@@ -30,7 +30,7 @@ const AppDetailHeader: React.FC<{ project: ProjectDetails }> = ({
           </p>
         </div>
         <div className="mt-4 sm:mt-0 sm:ml-4 flex-shrink-0 flex items-center">
-          <GitLink url={appMetadata.git_url} />
+          <GitLink url={appMetadata.git_url} showText={true} />
         </div>
       </div>
       <div className="mt-4 pt-4 border-t border-gray-700">

--- a/packages/frontend/src/pages/AppDetailPage/AppDetailHeader.tsx
+++ b/packages/frontend/src/pages/AppDetailPage/AppDetailHeader.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { ProjectDetails } from "@shared/domain/readModels/project/ProjectDetails.ts";
+import GitLink from "@sharedComponents/GitLink.tsx";
 
 const AppDetailHeader: React.FC<{ project: ProjectDetails }> = ({
   project,
@@ -28,29 +29,8 @@ const AppDetailHeader: React.FC<{ project: ProjectDetails }> = ({
               : "—"}
           </p>
         </div>
-        <div className="mt-4 sm:mt-0 sm:ml-4 flex-shrink-0 flex flex-col space-y-2 items-stretch">
-          {appMetadata.git_url && (
-            <a
-              href={appMetadata.git_url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="btn-secondary px-6 py-3 rounded-lg text-base font-semibold shadow-md hover:shadow-lg transition-all duration-200 ease-in-out transform hover:scale-105 flex items-center justify-center"
-            >
-              <svg
-                className="icon h-5 w-5 mr-2"
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 20 20"
-                fill="currentColor"
-              >
-                <path
-                  fillRule="evenodd"
-                  d="M12.316 3.051a1 1 0 01.633 1.265l-4 12a1 1 0 01-1.898.069l-2-6a1 1 0 011.265-.633L12.316 3.05zM11.34 8.033L10 11.588l.95-2.853-3.821-1.274 2.21.737zM16 6a1 1 0 011 1v3.586l-1.707-1.707A.996.996 0 0014.586 8H14V6h2zm-5.414-2H12V2.586l1.707 1.707A.996.996 0 0014.414 5H16v-.586A1.414 1.414 0 0014.586 3H12V2a1 1 0 00-1-1H4a1 1 0 00-1 1v14a1 1 0 001 1h8a1 1 0 001-1V9.414A1.414 1.414 0 0012.586 8H12V6.414A1.414 1.414 0 0010.586 5H8V4a1 1 0 011-1h1.586l.0001-.0001z"
-                  clipRule="evenodd"
-                />
-              </svg>
-              View Source
-            </a>
-          )}
+        <div className="mt-4 sm:mt-0 sm:ml-4 flex-shrink-0 flex items-center">
+          <GitLink url={appMetadata.git_url} />
         </div>
       </div>
       <div className="mt-4 pt-4 border-t border-gray-700">

--- a/packages/frontend/src/pages/AppEditPage/AppEditBasicInfo.tsx
+++ b/packages/frontend/src/pages/AppEditPage/AppEditBasicInfo.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { ProjectEditFormData } from "@pages/AppEditPage/ProjectEditFormData.ts";
+import GitLink from "@sharedComponents/GitLink.tsx";
 
 /**
  * A component for editing the basic information of an application.
@@ -54,9 +55,10 @@ const AppEditBasicInfo: React.FC<{
         <div>
           <label
             htmlFor="gitUrl"
-            className="block text-sm font-medium text-slate-300 mb-1"
+            className="block text-sm font-medium text-slate-300 mb-1 flex items-center"
           >
             Git URL
+            <GitLink url={form.git_url} />
           </label>
           <input
             type="url"

--- a/packages/frontend/src/sharedComponents/AppsGrid/AppCard.tsx
+++ b/packages/frontend/src/sharedComponents/AppsGrid/AppCard.tsx
@@ -69,21 +69,27 @@ const AppCard: React.FC<
         {/* Tags section pushed to bottom */}
         <div className="mt-auto mb-3">
           {(() => {
+            const MAX_VISIBLE_TAGS = 3;
             const allTags = [
-              ...(categories?.map((cat) => ({ text: cat, type: "category" })) ??
-                []),
-              ...(badges?.map((badge) => ({ text: badge, type: "badge" })) ??
-                []),
+              ...(categories?.map((cat, index) => ({
+                text: cat,
+                type: "category",
+                id: `category-${index}`,
+              })) ?? []),
+              ...(badges?.map((badge, index) => ({
+                text: badge,
+                type: "badge",
+                id: `badge-${index}`,
+              })) ?? []),
             ];
-            const maxVisibleTags = 3;
-            const visibleTags = allTags.slice(0, maxVisibleTags);
-            const hiddenCount = allTags.length - maxVisibleTags;
+            const visibleTags = allTags.slice(0, MAX_VISIBLE_TAGS);
+            const hiddenCount = allTags.length - MAX_VISIBLE_TAGS;
 
             return (
               <>
                 {visibleTags.map((tag) => (
                   <span
-                    key={`${tag.type}-${tag.text}`}
+                    key={tag.id}
                     className={`${
                       tag.type === "category" ? "tag" : "tag-mcu"
                     } text-xs font-semibold mr-2 px-2.5 py-0.5 rounded-full`}
@@ -95,7 +101,7 @@ const AppCard: React.FC<
                   <span
                     className="text-xs text-slate-500 font-medium cursor-help"
                     title={allTags
-                      .slice(maxVisibleTags)
+                      .slice(MAX_VISIBLE_TAGS)
                       .map((tag) => tag.text)
                       .join(", ")}
                   >

--- a/packages/frontend/src/sharedComponents/AppsGrid/AppCard.tsx
+++ b/packages/frontend/src/sharedComponents/AppsGrid/AppCard.tsx
@@ -68,22 +68,43 @@ const AppCard: React.FC<
 
         {/* Tags section pushed to bottom */}
         <div className="mt-auto mb-3">
-          {categories?.map((category) => (
-            <span
-              key={category}
-              className="tag text-xs font-semibold mr-2 px-2.5 py-0.5 rounded-full"
-            >
-              {category}
-            </span>
-          )) ?? false}
-          {badges?.map((badge) => (
-            <span
-              key={badge}
-              className="tag-mcu text-xs font-semibold mr-2 px-2.5 py-0.5 rounded-full"
-            >
-              {badge}
-            </span>
-          )) ?? false}
+          {(() => {
+            const allTags = [
+              ...(categories?.map((cat) => ({ text: cat, type: "category" })) ??
+                []),
+              ...(badges?.map((badge) => ({ text: badge, type: "badge" })) ??
+                []),
+            ];
+            const maxVisibleTags = 3;
+            const visibleTags = allTags.slice(0, maxVisibleTags);
+            const hiddenCount = allTags.length - maxVisibleTags;
+
+            return (
+              <>
+                {visibleTags.map((tag) => (
+                  <span
+                    key={`${tag.type}-${tag.text}`}
+                    className={`${
+                      tag.type === "category" ? "tag" : "tag-mcu"
+                    } text-xs font-semibold mr-2 px-2.5 py-0.5 rounded-full`}
+                  >
+                    {tag.text}
+                  </span>
+                ))}
+                {hiddenCount > 0 && (
+                  <span
+                    className="text-xs text-slate-500 font-medium cursor-help"
+                    title={allTags
+                      .slice(maxVisibleTags)
+                      .map((tag) => tag.text)
+                      .join(", ")}
+                  >
+                    +{hiddenCount} more
+                  </span>
+                )}
+              </>
+            );
+          })()}
         </div>
       </div>
 

--- a/packages/frontend/src/sharedComponents/AppsGrid/AppCard.tsx
+++ b/packages/frontend/src/sharedComponents/AppsGrid/AppCard.tsx
@@ -69,43 +69,71 @@ const AppCard: React.FC<
         {/* Tags section pushed to bottom */}
         <div className="mt-auto mb-3">
           {(() => {
-            const MAX_VISIBLE_TAGS = 3;
-            const allTags = [
-              ...(categories?.map((cat, index) => ({
-                text: cat,
-                type: "category",
-                id: `category-${index}`,
-              })) ?? []),
-              ...(badges?.map((badge, index) => ({
-                text: badge,
-                type: "badge",
-                id: `badge-${index}`,
-              })) ?? []),
-            ];
-            const visibleTags = allTags.slice(0, MAX_VISIBLE_TAGS);
-            const hiddenCount = allTags.length - MAX_VISIBLE_TAGS;
+            const MAX_VISIBLE_CATEGORIES = 1;
+            const MAX_VISIBLE_BADGES = 1;
+            
+            const categoryTags = categories?.map((cat, index) => ({
+              text: cat,
+              type: "category",
+              id: `category-${index}`,
+            })) ?? [];
+            
+            const badgeTags = badges?.map((badge, index) => ({
+              text: badge,
+              type: "badge", 
+              id: `badge-${index}`,
+            })) ?? [];
+
+            const visibleCategories = categoryTags.slice(0, MAX_VISIBLE_CATEGORIES);
+            const visibleBadges = badgeTags.slice(0, MAX_VISIBLE_BADGES);
+            const hiddenCategoryCount = Math.max(0, categoryTags.length - MAX_VISIBLE_CATEGORIES);
+            const hiddenBadgeCount = Math.max(0, badgeTags.length - MAX_VISIBLE_BADGES);
 
             return (
               <>
-                {visibleTags.map((tag) => (
+                {/* Show visible categories */}
+                {visibleCategories.map((tag) => (
                   <span
                     key={tag.id}
-                    className={`${
-                      tag.type === "category" ? "tag" : "tag-mcu"
-                    } text-xs font-semibold mr-2 px-2.5 py-0.5 rounded-full`}
+                    className="tag text-xs font-semibold mr-2 px-2.5 py-0.5 rounded-full"
                   >
                     {tag.text}
                   </span>
                 ))}
-                {hiddenCount > 0 && (
+                
+                {/* Show +X more categories */}
+                {hiddenCategoryCount > 0 && (
                   <span
-                    className="text-xs text-slate-500 font-medium cursor-help"
-                    title={allTags
-                      .slice(MAX_VISIBLE_TAGS)
+                    className="text-xs text-slate-500 font-medium cursor-help mr-2"
+                    title={categoryTags
+                      .slice(MAX_VISIBLE_CATEGORIES)
                       .map((tag) => tag.text)
                       .join(", ")}
                   >
-                    +{hiddenCount} more
+                    +{hiddenCategoryCount}
+                  </span>
+                )}
+                
+                {/* Show visible badges */}
+                {visibleBadges.map((tag) => (
+                  <span
+                    key={tag.id}
+                    className="tag-mcu text-xs font-semibold mr-2 px-2.5 py-0.5 rounded-full"
+                  >
+                    {tag.text}
+                  </span>
+                ))}
+                
+                {/* Show +X more badges */}
+                {hiddenBadgeCount > 0 && (
+                  <span
+                    className="text-xs text-slate-500 font-medium cursor-help"
+                    title={badgeTags
+                      .slice(MAX_VISIBLE_BADGES)
+                      .map((tag) => tag.text)
+                      .join(", ")}
+                  >
+                    +{hiddenBadgeCount}
                   </span>
                 )}
               </>

--- a/packages/frontend/src/sharedComponents/GitLink.tsx
+++ b/packages/frontend/src/sharedComponents/GitLink.tsx
@@ -4,6 +4,7 @@ import { GitLabIcon } from "./icons/GitLabIcon.tsx";
 
 interface GitLinkProps {
   url?: string;
+  showText?: boolean;
 }
 
 function urlHasHost(url: string, GITHUB_HOSTNAME: string) {
@@ -18,32 +19,38 @@ function urlHasHost(url: string, GITHUB_HOSTNAME: string) {
  * Renders a GitHub or GitLab icon linking to the provided source code URL.
  * It returns null if the URL is not provided or not from a supported provider.
  */
-const GitLink: React.FC<GitLinkProps> = ({ url }) => {
+const GitLink: React.FC<GitLinkProps> = ({ url, showText = false }) => {
   if (!url) {
     return null;
   }
 
   const GITHUB_HOSTNAME = "github.com";
-  const GitIcon = urlHasHost(url, GITHUB_HOSTNAME)
-    ? GitHubIcon
-    : urlHasHost(url, "gitlab.com")
-      ? GitLabIcon
-      : null;
+  const isGitHub = urlHasHost(url, GITHUB_HOSTNAME);
+  const isGitLab = urlHasHost(url, "gitlab.com");
+
+  const GitIcon = isGitHub ? GitHubIcon : isGitLab ? GitLabIcon : null;
 
   if (!GitIcon) {
     return null; // Only render for supported Git providers
   }
+
+  const providerName = isGitHub ? "GitHub" : "GitLab";
 
   return (
     <a
       href={url}
       target="_blank"
       rel="noopener noreferrer"
-      className="text-slate-400 hover:text-white transition-colors ml-2 flex-shrink-0"
-      aria-label="Source code repository"
-      title="Source Code Repository"
+      className={
+        showText
+          ? "btn-secondary px-4 py-2 rounded-lg text-sm font-semibold shadow-md hover:shadow-lg transition-all duration-200 flex items-center"
+          : "text-slate-400 hover:text-white transition-colors ml-2 flex-shrink-0"
+      }
+      aria-label={`Source code repository on ${providerName}`}
+      title={`View source code on ${providerName}`}
     >
       <GitIcon className="h-5 w-5" />
+      {showText && <span className="ml-2">View Source</span>}
     </a>
   );
 };

--- a/packages/frontend/src/sharedComponents/GitLink.tsx
+++ b/packages/frontend/src/sharedComponents/GitLink.tsx
@@ -24,28 +24,35 @@ const GitLink: React.FC<GitLinkProps> = ({ url, showText = false }) => {
     return null;
   }
 
-  const GITHUB_HOSTNAME = "github.com";
-  const isGitHub = urlHasHost(url, GITHUB_HOSTNAME);
-  const isGitLab = urlHasHost(url, "gitlab.com");
+  // Git provider configuration - easy to extend for more providers
+  const gitProviders = {
+    "github.com": { icon: GitHubIcon, name: "GitHub" },
+    "gitlab.com": { icon: GitLabIcon, name: "GitLab" },
+  };
 
-  const GitIcon = isGitHub ? GitHubIcon : isGitLab ? GitLabIcon : null;
+  const provider = Object.entries(gitProviders).find(([hostname]) =>
+    urlHasHost(url, hostname)
+  )?.[1];
 
-  if (!GitIcon) {
+  if (!provider) {
     return null; // Only render for supported Git providers
   }
 
-  const providerName = isGitHub ? "GitHub" : "GitLab";
+  const { icon: GitIcon, name: providerName } = provider;
+
+  // Style configurations for better maintainability
+  const styles = {
+    button:
+      "btn-secondary px-4 py-2 rounded-lg text-sm font-semibold shadow-md hover:shadow-lg transition-all duration-200 flex items-center",
+    icon: "text-slate-400 hover:text-white transition-colors ml-2 flex-shrink-0",
+  };
 
   return (
     <a
       href={url}
       target="_blank"
       rel="noopener noreferrer"
-      className={
-        showText
-          ? "btn-secondary px-4 py-2 rounded-lg text-sm font-semibold shadow-md hover:shadow-lg transition-all duration-200 flex items-center"
-          : "text-slate-400 hover:text-white transition-colors ml-2 flex-shrink-0"
-      }
+      className={showText ? styles.button : styles.icon}
       aria-label={`Source code repository on ${providerName}`}
       title={`View source code on ${providerName}`}
     >


### PR DESCRIPTION
## Summary

- Show 1 category and 1 badge by default to prevent tag overflow
- Use compact "+X" counters instead of verbose text for additional items
- Separate counters for categories and badges
- Tooltips show full list of hidden items on hover

## Changes

The AppCard component now displays:
- First category (if any) + "+X" for additional categories
- First badge (if any) + "+X" for additional badges  
- Compact display prevents wrapping to multiple lines

## Test plan

- [x] TypeScript compilation passes
- [x] Component renders correctly with various tag combinations
- [x] Tooltips show proper hidden item lists
- [ ] Visual testing with apps having multiple categories/badges